### PR TITLE
ld's backward compatibility for debian like OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
 RUN apk upgrade --update-cache; \
     apk add openjdk8-jre; \
-    rm -rf /tmp/* /var/cache/apk/*
+    rm -rf /tmp/* /var/cache/apk/*; \
+    # ld's backward compatibility for debian like OS
+    mkdir /lib64 && ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 CMD ["java", "-version"]


### PR DESCRIPTION
Will help to avoid many headaches like [this](https://github.com/pires/kubernetes-elasticsearch-cluster/issues/102) ...

> The program ld.so handles a.out binaries, a format used long ago; ld-linux.so* ( /lib/ld-linux.so.1 for libc5, /lib/ld-linux.so.2 for glibc2) handles ELF, which everybody has been using for years now. Otherwise, both have the same behavior, and use the same support files and programs ldd(1), ldconfig(8), and /etc/ld.so.conf.

> In the default path /lib, and then /usr/lib. (On some 64-bit architectures, the default paths for 64-bit shared objects are /lib64, and then /usr/lib64.) If the binary was linked with the -z nodeflib linker option, this step is skipped.

[Read more](https://manpages.debian.org/stretch/manpages/ld.so.8.en.html#DESCRIPTION)
